### PR TITLE
Add Python LETKF runner and utilities

### DIFF
--- a/pyletkf/__init__.py
+++ b/pyletkf/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities to run a LETKF experiment using the Python common module."""
+
+from .assimilation import run_letkf_assimilation
+from .io import load_ensemble, load_observations, save_outputs
+
+__all__ = [
+    "load_ensemble",
+    "load_observations",
+    "run_letkf_assimilation",
+    "save_outputs",
+]

--- a/pyletkf/__init__.py
+++ b/pyletkf/__init__.py
@@ -2,10 +2,14 @@
 
 from .assimilation import run_letkf_assimilation
 from .io import load_ensemble, load_observations, save_outputs
+from .localization import gaspari_cohn
+from .mpi import get_world_comm
 
 __all__ = [
     "load_ensemble",
     "load_observations",
     "run_letkf_assimilation",
     "save_outputs",
+    "gaspari_cohn",
+    "get_world_comm",
 ]

--- a/pyletkf/assimilation.py
+++ b/pyletkf/assimilation.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Sequence
 
 import numpy as np
 import xarray as xr
 
 from common.common_letkf import letkf_core
+
+from .localization import gaspari_cohn
+from .mpi import MPI, get_world_comm
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,82 +28,78 @@ class AssimilationResult:
     inflation: float
 
 
-def build_hist_time_selector(len_hist: int, len_total: int) -> np.ndarray:
-    """Return the extraction matrix that isolates historical times.
+def _normalise_coordinate(values: np.ndarray) -> np.ndarray:
+    """Convert arbitrary coordinate arrays to floating point values."""
 
-    The matrix mimics the behaviour of the historical Fortran implementation by
-    placing an identity matrix in the top-left corner and zeros elsewhere.
-    """
-
-    selector = np.zeros((len_hist, len_total), dtype=float)
-    selector[:, :len_hist] = np.eye(len_hist, dtype=float)
-    return selector
-
-
-def _stack_state(data: xr.DataArray, member_dim: str, state_dims: Iterable[str]) -> np.ndarray:
-    ordered = data.transpose(member_dim, *state_dims)
-    ne = ordered.sizes[member_dim]
-    state_size = int(np.prod([ordered.sizes[dim] for dim in state_dims]))
-    values = ordered.values.reshape(ne, state_size).T
-    return values
+    array = np.asarray(values)
+    if np.issubdtype(array.dtype, np.datetime64):
+        array = array.astype("datetime64[ns]").astype(np.int64)
+    elif np.issubdtype(array.dtype, np.timedelta64):
+        array = array.astype("timedelta64[ns]").astype(np.int64)
+    elif not np.issubdtype(array.dtype, np.number):
+        return np.arange(array.size, dtype=float)
+    return array.astype(float)
 
 
-def _reshape_state(
-    values: np.ndarray,
-    template: xr.DataArray,
-    state_dims: Iterable[str],
-) -> xr.DataArray:
-    ordered = template.transpose(*state_dims)
-    data = values.reshape([ordered.sizes[dim] for dim in state_dims])
-    reshaped = xr.DataArray(
-        data,
-        coords={dim: ordered.coords[dim] for dim in state_dims},
-        dims=tuple(state_dims),
-        attrs=template.attrs,
-    )
-    reshaped.name = template.name
-    return reshaped
+def _space_coordinate_matrix(space_coord: xr.Coordinate, space_dims: Sequence[str]) -> np.ndarray:
+    """Return a coordinate matrix used to compute spatial distances."""
+
+    index = space_coord.to_index()
+    if getattr(index, "nlevels", 1) == 1:
+        values = _normalise_coordinate(index.values)
+        return values.reshape(-1, 1)
+
+    columns = []
+    for dim in space_dims:
+        level = index.get_level_values(dim).to_numpy()
+        columns.append(_normalise_coordinate(level))
+    if not columns:
+        return np.zeros((index.size, 0), dtype=float)
+    return np.column_stack(columns)
 
 
-def _collect_observations(
+def _prepare_observations(
     obs: xr.DataArray,
-    hist_template: xr.DataArray,
+    obs_error_var: float | xr.DataArray,
+    template: xr.DataArray,
     *,
     time_dim: str,
-    state_dims: Iterable[str],
-    obs_error_var: float | xr.DataArray,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Extract observation values, indices and variances."""
+    space_dims: Sequence[str],
+) -> tuple[np.ndarray, np.ndarray, list[np.ndarray]]:
+    """Align observations and their error variances with the model grid."""
 
-    target_coords = {time_dim: hist_template.coords[time_dim]}
-    for dim in state_dims:
-        if dim in (time_dim,):
-            continue
-        if dim in hist_template.dims and dim in obs.dims:
-            target_coords[dim] = hist_template.coords[dim]
+    coords = {time_dim: template.coords[time_dim]}
+    for dim in space_dims:
+        coords[dim] = template.coords[dim]
 
-    obs_on_hist = obs.reindex(target_coords)
-    obs_on_hist = obs_on_hist.transpose(time_dim, *[dim for dim in state_dims if dim != time_dim])
-    stacked = obs_on_hist.stack(obs_state=(time_dim, *[dim for dim in state_dims if dim != time_dim]))
-    values = stacked.values
+    obs_on_grid = obs.reindex(coords)
+    obs_flat = obs_on_grid.stack(space=space_dims).transpose(time_dim, "space")
+    obs_values = obs_flat.values.astype(float)
 
     if isinstance(obs_error_var, xr.DataArray):
-        obs_var = obs_error_var.reindex(target_coords)
-        obs_var = obs_var.transpose(time_dim, *[dim for dim in state_dims if dim != time_dim])
-        obs_var = obs_var.stack(obs_state=(time_dim, *[dim for dim in state_dims if dim != time_dim]))
-        var_values = obs_var.values.astype(float)
+        obs_var = obs_error_var.reindex(coords)
+        obs_var_flat = obs_var.stack(space=space_dims).transpose(time_dim, "space").values.astype(float)
     else:
-        var_values = np.full_like(values, float(obs_error_var), dtype=float)
+        obs_var_flat = np.full(obs_values.shape, float(obs_error_var), dtype=float)
 
-    valid_mask = np.isfinite(values) & np.isfinite(var_values) & (var_values > 0.0)
-    if not np.any(valid_mask):
-        return np.empty(0, dtype=float), np.empty(0, dtype=int), np.empty(0, dtype=float)
+    valid_mask = np.isfinite(obs_values) & np.isfinite(obs_var_flat) & (obs_var_flat > 0.0)
+    obs_indices = [np.nonzero(valid_mask[t])[0] for t in range(valid_mask.shape[0])]
 
-    indices = np.nonzero(valid_mask)[0]
-    obs_values = values[valid_mask]
-    obs_var_values = var_values[valid_mask]
+    return obs_values, obs_var_flat, obs_indices
 
-    return obs_values.astype(float), indices.astype(int), obs_var_values.astype(float)
+
+def _stack_ensemble(
+    data: xr.DataArray,
+    *,
+    member_dim: str,
+    time_dim: str,
+    space_dims: Sequence[str],
+) -> tuple[np.ndarray, xr.Coordinate]:
+    """Return the ensemble as an array shaped ``(nspace, ntime, ne)``."""
+
+    stacked = data.stack(space=space_dims)
+    stacked = stacked.transpose("space", time_dim, member_dim)
+    return stacked.values.astype(float), stacked.coords["space"]
 
 
 def run_letkf_assimilation(
@@ -112,11 +111,15 @@ def run_letkf_assimilation(
     time_dim: str = "year",
     obs_error_var: float | xr.DataArray = 1.0,
     inflation: float = 1.0,
+    localization_radius: float | None = None,
+    comm=None,
 ) -> AssimilationResult:
     """Assimilate *obs* into the ensemble defined by *hist* and *fut*.
 
-    The returned :class:`AssimilationResult` only contains ensemble statistics
-    (mean and standard deviation) in accordance with the user requirements.
+    The returned :class:`AssimilationResult` contains ensemble statistics (mean and
+    spread).  Spatial localisation follows the Gaspari--Cohn taper.  When an MPI
+    communicator is provided or automatically detected, spatial grid points are
+    distributed evenly across the participating ranks.
     """
 
     if hist.dims != fut.dims:
@@ -127,81 +130,194 @@ def run_letkf_assimilation(
         raise ValueError("Historical and future ensembles must have the same size")
     if hist.sizes[member_dim] < 2:
         raise ValueError("At least two ensemble members are required")
-
     if time_dim not in hist.dims:
         raise ValueError(f"Historical data is missing the {time_dim!r} dimension")
+    if localization_radius is not None and localization_radius <= 0.0:
+        raise ValueError("The localisation radius must be positive")
 
-    state_dims = [dim for dim in hist.dims if dim != member_dim]
-    if time_dim not in state_dims:
-        raise ValueError(f"Historical data does not contain the time dimension {time_dim!r}")
-    state_dims.remove(time_dim)
-    state_dims = [time_dim] + state_dims
+    if comm is None:
+        comm = get_world_comm()
+    if comm is not None:
+        size = comm.Get_size()
+        rank = comm.Get_rank()
+    else:
+        size = 1
+        rank = 0
 
-    hist = hist.transpose(member_dim, *state_dims)
-    fut = fut.transpose(member_dim, *state_dims)
+    space_dims = [dim for dim in hist.dims if dim not in (member_dim, time_dim)]
+    if not space_dims:
+        raise ValueError("At least one spatial dimension is required for localisation")
+
+    hist = hist.transpose(member_dim, time_dim, *space_dims)
+    fut = fut.transpose(member_dim, time_dim, *space_dims)
     combined = xr.concat([hist, fut], dim=time_dim)
 
-    prior_mean = combined.mean(dim=member_dim)
-    prior_std = combined.std(dim=member_dim, ddof=1)
+    template = combined.mean(dim=member_dim)
 
-    hist_len = hist.sizes[time_dim]
-    total_len = combined.sizes[time_dim]
-
-    LOGGER.debug("Historical samples: %s, combined samples: %s", hist_len, total_len)
-    time_selector = build_hist_time_selector(hist_len, total_len)
-    if not np.array_equal(time_selector[:, :hist_len], np.eye(hist_len)):
-        raise RuntimeError("Invalid historical time selector")
-
-    xb = _stack_state(combined, member_dim, state_dims)
-    xb_mean = xb.mean(axis=1)
-    xb_pert = xb - xb_mean[:, None]
-    ne = xb.shape[1]
-
-    hist_template = hist.mean(dim=member_dim)
-    obs_values, obs_indices, obs_var = _collect_observations(
-        obs, hist_template, time_dim=time_dim, state_dims=state_dims, obs_error_var=obs_error_var
+    ensemble_values, space_coord = _stack_ensemble(
+        combined, member_dim=member_dim, time_dim=time_dim, space_dims=space_dims
     )
+    nspace, ntime_total, ne = ensemble_values.shape
 
-    if obs_values.size == 0:
-        LOGGER.warning("No valid observations found; analysis equals the background")
-        post_mean = prior_mean
-        post_std = prior_std
-        return AssimilationResult(prior_mean, prior_std, post_mean, post_std, inflation)
+    xb_mean = ensemble_values.mean(axis=2)
+    xb_pert = ensemble_values - xb_mean[..., None]
+    prior_std_values = np.sqrt(np.sum(xb_pert**2, axis=2) / float(ne - 1))
 
-    points_per_time = int(np.prod([hist.sizes[dim] for dim in state_dims if dim != time_dim]))
-    hist_time_mask = time_selector.any(axis=0)
-    hist_state_mask = np.repeat(hist_time_mask, points_per_time)
-    if np.any(~hist_state_mask[obs_indices]):
-        raise IndexError("Observation index exceeds historical state extent")
+    coords = {"space": space_coord, time_dim: combined.coords[time_dim]}
+    prior_mean = xr.DataArray(xb_mean, coords=coords, dims=("space", time_dim)).unstack("space")
+    prior_std = xr.DataArray(prior_std_values, coords=coords, dims=("space", time_dim)).unstack("space")
+    prior_mean = prior_mean.transpose(time_dim, *space_dims)
+    prior_std = prior_std.transpose(time_dim, *space_dims)
+    prior_mean.name = hist.name
+    prior_std.name = hist.name
+    prior_mean.attrs.update(hist.attrs)
+    prior_std.attrs.update(hist.attrs)
 
-    hx = xb[obs_indices, :]
-    hx_mean = hx.mean(axis=1)
-    hdxb = hx - hx_mean[:, None]
-    dep = obs_values - hx_mean
-
-    rdiag = obs_var
-    rloc = np.ones_like(rdiag)
-
-    LOGGER.info("Running LETKF update for %d observations and %d ensemble members", obs_values.size, ne)
-    result = letkf_core(
-        hdxb,
-        rdiag,
-        rloc,
-        dep,
-        inflation,
-        return_transm=True,
+    obs_values, obs_var_values, obs_indices_per_time = _prepare_observations(
+        obs,
+        obs_error_var,
+        template,
+        time_dim=time_dim,
+        space_dims=space_dims,
     )
+    total_obs = int(sum(len(indices) for indices in obs_indices_per_time))
 
-    trans = result["trans"]
-    transm = result["transm"]
-    updated_inflation = float(result.get("parm_infl", inflation))
+    space_coordinates = _space_coordinate_matrix(space_coord, space_dims)
 
-    xa_pert = xb_pert @ trans.T
-    mean_increment = xb_pert @ transm
-    xa_mean = xb_mean + mean_increment
-    xa_std = np.sqrt(np.sum(xa_pert**2, axis=1) / float(ne - 1))
+    if rank == 0:
+        LOGGER.info(
+            "Running LETKF update for %d spatial points, %d time steps, %d ensemble members and %d observations",
+            nspace,
+            ntime_total,
+            ne,
+            total_obs,
+        )
+        if localization_radius is not None:
+            LOGGER.info("Using Gaspari--Cohn localisation radius %.3f", localization_radius)
+        elif total_obs == 0:
+            LOGGER.warning("No valid observations found; analysis equals the background")
 
-    post_mean = _reshape_state(xa_mean, prior_mean, state_dims)
-    post_std = _reshape_state(xa_std, prior_std, state_dims)
+    post_mean_local = np.zeros_like(xb_mean)
+    post_std_local = np.zeros_like(prior_std_values)
+    inflation_sum = 0.0
+    successful_updates = 0
 
-    return AssimilationResult(prior_mean, prior_std, post_mean, post_std, updated_inflation)
+    assigned_indices: Iterable[int]
+    if size > 1:
+        assigned_indices = range(rank, nspace, size)
+    else:
+        assigned_indices = range(nspace)
+
+    for space_index in assigned_indices:
+        xb_local_mean = xb_mean[space_index, :]
+        xb_local_pert = xb_pert[space_index, :, :]
+        prior_std_local = prior_std_values[space_index, :]
+
+        hdxb_chunks: list[np.ndarray] = []
+        dep_chunks: list[np.ndarray] = []
+        rdiag_chunks: list[np.ndarray] = []
+        rloc_chunks: list[np.ndarray] = []
+
+        for time_index, obs_indices in enumerate(obs_indices_per_time):
+            if obs_indices.size == 0:
+                continue
+
+            hx_mean = xb_mean[obs_indices, time_index]
+            hdxb = xb_pert[obs_indices, time_index, :]
+            obs_val = obs_values[time_index, obs_indices]
+            obs_var = obs_var_values[time_index, obs_indices]
+
+            if localization_radius is not None:
+                distances = np.linalg.norm(
+                    space_coordinates[obs_indices, :] - space_coordinates[space_index, :], axis=1
+                )
+                weights = gaspari_cohn(distances, localization_radius)
+            else:
+                weights = np.ones_like(obs_val, dtype=float)
+
+            mask = (
+                (weights > 0.0)
+                & np.isfinite(weights)
+                & np.isfinite(hx_mean)
+                & np.isfinite(obs_val)
+                & np.isfinite(obs_var)
+            )
+            if not np.any(mask):
+                continue
+
+            hdxb_chunks.append(hdxb[mask, :])
+            dep_chunks.append(obs_val[mask] - hx_mean[mask])
+            rdiag_chunks.append(obs_var[mask])
+            rloc_chunks.append(weights[mask])
+
+        if not hdxb_chunks:
+            post_mean_local[space_index, :] = xb_local_mean
+            post_std_local[space_index, :] = prior_std_local
+            continue
+
+        hdxb_matrix = np.vstack(hdxb_chunks).astype(float)
+        dep_vector = np.concatenate(dep_chunks).astype(float)
+        rdiag_vector = np.concatenate(rdiag_chunks).astype(float)
+        rloc_vector = np.concatenate(rloc_chunks).astype(float)
+
+        result = letkf_core(
+            hdxb_matrix,
+            rdiag_vector,
+            rloc_vector,
+            dep_vector,
+            inflation,
+            return_transm=True,
+        )
+
+        trans = result["trans"]
+        transm = result["transm"]
+        updated_inflation = float(result.get("parm_infl", inflation))
+
+        xa_pert = xb_local_pert @ trans.T
+        mean_increment = xb_local_pert @ transm
+        xa_mean = xb_local_mean + mean_increment
+        xa_std = np.sqrt(np.sum(xa_pert**2, axis=1) / float(ne - 1))
+
+        post_mean_local[space_index, :] = xa_mean
+        post_std_local[space_index, :] = xa_std
+        inflation_sum += updated_inflation
+        successful_updates += 1
+
+    if comm is not None and size > 1:
+        post_mean_total = np.zeros_like(post_mean_local)
+        comm.Allreduce(post_mean_local, post_mean_total, op=MPI.SUM)
+        post_std_total = np.zeros_like(post_std_local)
+        comm.Allreduce(post_std_local, post_std_total, op=MPI.SUM)
+
+        buffer = np.array([inflation_sum, float(successful_updates)], dtype=float)
+        global_buffer = np.zeros_like(buffer)
+        comm.Allreduce(buffer, global_buffer, op=MPI.SUM)
+        inflation_sum_total = global_buffer[0]
+        inflation_count_total = int(round(global_buffer[1]))
+    else:
+        post_mean_total = post_mean_local
+        post_std_total = post_std_local
+        inflation_sum_total = inflation_sum
+        inflation_count_total = successful_updates
+
+    coords = {"space": space_coord, time_dim: combined.coords[time_dim]}
+    post_mean = xr.DataArray(post_mean_total, coords=coords, dims=("space", time_dim)).unstack("space")
+    post_std = xr.DataArray(post_std_total, coords=coords, dims=("space", time_dim)).unstack("space")
+    post_mean = post_mean.transpose(time_dim, *space_dims)
+    post_std = post_std.transpose(time_dim, *space_dims)
+    post_mean.name = hist.name
+    post_std.name = hist.name
+    post_mean.attrs.update(hist.attrs)
+    post_std.attrs.update(hist.attrs)
+
+    if inflation_count_total > 0:
+        final_inflation = float(inflation_sum_total / float(inflation_count_total))
+    else:
+        final_inflation = float(inflation)
+
+    if rank == 0:
+        LOGGER.info(
+            "Completed LETKF updates for %d of %d spatial points", inflation_count_total, nspace
+        )
+
+    return AssimilationResult(prior_mean, prior_std, post_mean, post_std, final_inflation)

--- a/pyletkf/assimilation.py
+++ b/pyletkf/assimilation.py
@@ -1,0 +1,207 @@
+"""LETKF driver utilities working on :mod:`xarray` objects."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import xarray as xr
+
+from common.common_letkf import letkf_core
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class AssimilationResult:
+    """Container for prior and posterior statistics."""
+
+    prior_mean: xr.DataArray
+    prior_std: xr.DataArray
+    post_mean: xr.DataArray
+    post_std: xr.DataArray
+    inflation: float
+
+
+def build_hist_time_selector(len_hist: int, len_total: int) -> np.ndarray:
+    """Return the extraction matrix that isolates historical times.
+
+    The matrix mimics the behaviour of the historical Fortran implementation by
+    placing an identity matrix in the top-left corner and zeros elsewhere.
+    """
+
+    selector = np.zeros((len_hist, len_total), dtype=float)
+    selector[:, :len_hist] = np.eye(len_hist, dtype=float)
+    return selector
+
+
+def _stack_state(data: xr.DataArray, member_dim: str, state_dims: Iterable[str]) -> np.ndarray:
+    ordered = data.transpose(member_dim, *state_dims)
+    ne = ordered.sizes[member_dim]
+    state_size = int(np.prod([ordered.sizes[dim] for dim in state_dims]))
+    values = ordered.values.reshape(ne, state_size).T
+    return values
+
+
+def _reshape_state(
+    values: np.ndarray,
+    template: xr.DataArray,
+    state_dims: Iterable[str],
+) -> xr.DataArray:
+    ordered = template.transpose(*state_dims)
+    data = values.reshape([ordered.sizes[dim] for dim in state_dims])
+    reshaped = xr.DataArray(
+        data,
+        coords={dim: ordered.coords[dim] for dim in state_dims},
+        dims=tuple(state_dims),
+        attrs=template.attrs,
+    )
+    reshaped.name = template.name
+    return reshaped
+
+
+def _collect_observations(
+    obs: xr.DataArray,
+    hist_template: xr.DataArray,
+    *,
+    time_dim: str,
+    state_dims: Iterable[str],
+    obs_error_var: float | xr.DataArray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Extract observation values, indices and variances."""
+
+    target_coords = {time_dim: hist_template.coords[time_dim]}
+    for dim in state_dims:
+        if dim in (time_dim,):
+            continue
+        if dim in hist_template.dims and dim in obs.dims:
+            target_coords[dim] = hist_template.coords[dim]
+
+    obs_on_hist = obs.reindex(target_coords)
+    obs_on_hist = obs_on_hist.transpose(time_dim, *[dim for dim in state_dims if dim != time_dim])
+    stacked = obs_on_hist.stack(obs_state=(time_dim, *[dim for dim in state_dims if dim != time_dim]))
+    values = stacked.values
+
+    if isinstance(obs_error_var, xr.DataArray):
+        obs_var = obs_error_var.reindex(target_coords)
+        obs_var = obs_var.transpose(time_dim, *[dim for dim in state_dims if dim != time_dim])
+        obs_var = obs_var.stack(obs_state=(time_dim, *[dim for dim in state_dims if dim != time_dim]))
+        var_values = obs_var.values.astype(float)
+    else:
+        var_values = np.full_like(values, float(obs_error_var), dtype=float)
+
+    valid_mask = np.isfinite(values) & np.isfinite(var_values) & (var_values > 0.0)
+    if not np.any(valid_mask):
+        return np.empty(0, dtype=float), np.empty(0, dtype=int), np.empty(0, dtype=float)
+
+    indices = np.nonzero(valid_mask)[0]
+    obs_values = values[valid_mask]
+    obs_var_values = var_values[valid_mask]
+
+    return obs_values.astype(float), indices.astype(int), obs_var_values.astype(float)
+
+
+def run_letkf_assimilation(
+    hist: xr.DataArray,
+    fut: xr.DataArray,
+    obs: xr.DataArray,
+    *,
+    member_dim: str = "member",
+    time_dim: str = "year",
+    obs_error_var: float | xr.DataArray = 1.0,
+    inflation: float = 1.0,
+) -> AssimilationResult:
+    """Assimilate *obs* into the ensemble defined by *hist* and *fut*.
+
+    The returned :class:`AssimilationResult` only contains ensemble statistics
+    (mean and standard deviation) in accordance with the user requirements.
+    """
+
+    if hist.dims != fut.dims:
+        raise ValueError("Historical and future ensembles must share dimensions")
+    if member_dim not in hist.dims:
+        raise ValueError(f"Historical data is missing the {member_dim!r} dimension")
+    if hist.sizes[member_dim] != fut.sizes[member_dim]:
+        raise ValueError("Historical and future ensembles must have the same size")
+    if hist.sizes[member_dim] < 2:
+        raise ValueError("At least two ensemble members are required")
+
+    if time_dim not in hist.dims:
+        raise ValueError(f"Historical data is missing the {time_dim!r} dimension")
+
+    state_dims = [dim for dim in hist.dims if dim != member_dim]
+    if time_dim not in state_dims:
+        raise ValueError(f"Historical data does not contain the time dimension {time_dim!r}")
+    state_dims.remove(time_dim)
+    state_dims = [time_dim] + state_dims
+
+    hist = hist.transpose(member_dim, *state_dims)
+    fut = fut.transpose(member_dim, *state_dims)
+    combined = xr.concat([hist, fut], dim=time_dim)
+
+    prior_mean = combined.mean(dim=member_dim)
+    prior_std = combined.std(dim=member_dim, ddof=1)
+
+    hist_len = hist.sizes[time_dim]
+    total_len = combined.sizes[time_dim]
+
+    LOGGER.debug("Historical samples: %s, combined samples: %s", hist_len, total_len)
+    time_selector = build_hist_time_selector(hist_len, total_len)
+    if not np.array_equal(time_selector[:, :hist_len], np.eye(hist_len)):
+        raise RuntimeError("Invalid historical time selector")
+
+    xb = _stack_state(combined, member_dim, state_dims)
+    xb_mean = xb.mean(axis=1)
+    xb_pert = xb - xb_mean[:, None]
+    ne = xb.shape[1]
+
+    hist_template = hist.mean(dim=member_dim)
+    obs_values, obs_indices, obs_var = _collect_observations(
+        obs, hist_template, time_dim=time_dim, state_dims=state_dims, obs_error_var=obs_error_var
+    )
+
+    if obs_values.size == 0:
+        LOGGER.warning("No valid observations found; analysis equals the background")
+        post_mean = prior_mean
+        post_std = prior_std
+        return AssimilationResult(prior_mean, prior_std, post_mean, post_std, inflation)
+
+    points_per_time = int(np.prod([hist.sizes[dim] for dim in state_dims if dim != time_dim]))
+    hist_time_mask = time_selector.any(axis=0)
+    hist_state_mask = np.repeat(hist_time_mask, points_per_time)
+    if np.any(~hist_state_mask[obs_indices]):
+        raise IndexError("Observation index exceeds historical state extent")
+
+    hx = xb[obs_indices, :]
+    hx_mean = hx.mean(axis=1)
+    hdxb = hx - hx_mean[:, None]
+    dep = obs_values - hx_mean
+
+    rdiag = obs_var
+    rloc = np.ones_like(rdiag)
+
+    LOGGER.info("Running LETKF update for %d observations and %d ensemble members", obs_values.size, ne)
+    result = letkf_core(
+        hdxb,
+        rdiag,
+        rloc,
+        dep,
+        inflation,
+        return_transm=True,
+    )
+
+    trans = result["trans"]
+    transm = result["transm"]
+    updated_inflation = float(result.get("parm_infl", inflation))
+
+    xa_pert = xb_pert @ trans.T
+    mean_increment = xb_pert @ transm
+    xa_mean = xb_mean + mean_increment
+    xa_std = np.sqrt(np.sum(xa_pert**2, axis=1) / float(ne - 1))
+
+    post_mean = _reshape_state(xa_mean, prior_mean, state_dims)
+    post_std = _reshape_state(xa_std, prior_std, state_dims)
+
+    return AssimilationResult(prior_mean, prior_std, post_mean, post_std, updated_inflation)

--- a/pyletkf/io.py
+++ b/pyletkf/io.py
@@ -62,8 +62,11 @@ def load_ensemble(
             if reindexer:
                 data = data.reindex(reindexer)
 
+        # ``expand_dims`` with a coordinate mapping already labels the new
+        # dimension using the provided values, so there is no need to add a
+        # scalar coordinate afterwards (which can clash with existing scalar
+        # coordinates named ``member_dim``).
         data = data.expand_dims({member_dim: [idx]})
-        data = data.assign_coords({member_dim: idx})
         members.append(data)
 
     ensemble = xr.concat(members, dim=member_dim)

--- a/pyletkf/io.py
+++ b/pyletkf/io.py
@@ -1,0 +1,105 @@
+"""Input/output helpers for the stand-alone Python LETKF pipeline."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import xarray as xr
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_nc_files(directory: Path) -> list[Path]:
+    files = sorted(path for path in directory.iterdir() if path.suffix == ".nc")
+    if not files:
+        raise FileNotFoundError(f"No NetCDF files found in {directory!s}")
+    return files
+
+
+def load_ensemble(
+    directory: str | Path,
+    var_name: str,
+    *,
+    member_dim: str = "member",
+    load_coords: Mapping[str, Iterable] | None = None,
+) -> xr.DataArray:
+    """Load ensemble members from NetCDF files in *directory*.
+
+    Parameters
+    ----------
+    directory:
+        Folder containing one NetCDF file per ensemble member.
+    var_name:
+        Name of the state variable to load.
+    member_dim:
+        Name of the ensemble dimension to create.
+    load_coords:
+        Optional mapping of dimension name to coordinates.  When provided, the
+        resulting data are reindexed onto these coordinates which is useful to
+        enforce a consistent grid between different ensemble batches.
+    """
+
+    directory = Path(directory)
+    files = _ensure_nc_files(directory)
+
+    members: list[xr.DataArray] = []
+    for idx, path in enumerate(files):
+        LOGGER.info("Loading ensemble member from %s", path)
+        with xr.open_dataset(path) as ds:
+            if var_name not in ds:
+                raise KeyError(f"Variable {var_name!r} not found in {path!s}")
+            data = ds[var_name].load()
+
+        if member_dim in data.dims:
+            raise ValueError(
+                f"Variable {var_name!r} in {path!s} already has a {member_dim!r} dimension"
+            )
+
+        if load_coords is not None:
+            reindexer = {dim: coords for dim, coords in load_coords.items() if dim in data.dims}
+            if reindexer:
+                data = data.reindex(reindexer)
+
+        data = data.expand_dims({member_dim: [idx]})
+        data = data.assign_coords({member_dim: idx})
+        members.append(data)
+
+    ensemble = xr.concat(members, dim=member_dim)
+    ensemble.attrs["source_files"] = [str(path) for path in files]
+    return ensemble
+
+
+def load_observations(path: str | Path, var_name: str) -> xr.DataArray:
+    """Load the observation field from *path*."""
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Observation file {path!s} not found")
+
+    LOGGER.info("Loading observations from %s", path)
+    with xr.open_dataset(path) as ds:
+        if var_name not in ds:
+            raise KeyError(f"Variable {var_name!r} not present in {path!s}")
+        data = ds[var_name].load()
+
+    data.attrs["source_file"] = str(path)
+    return data
+
+
+def save_outputs(outputs: Mapping[str, xr.DataArray], output_dir: str | Path) -> None:
+    """Persist output fields to NetCDF files.
+
+    The *outputs* mapping should associate a relative file name with the
+    corresponding :class:`xarray.DataArray` that is to be saved.
+    """
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename, data in outputs.items():
+        path = output_dir / filename
+        dataset = data.to_dataset(name=data.name or "value")
+        LOGGER.info("Writing %s", path)
+        dataset.to_netcdf(path)

--- a/pyletkf/localization.py
+++ b/pyletkf/localization.py
@@ -1,0 +1,38 @@
+"""Localization utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["gaspari_cohn"]
+
+
+def gaspari_cohn(distances: np.ndarray, radius: float) -> np.ndarray:
+    """Return Gaspari--Cohn taper weights for *distances* and localisation *radius*.
+
+    The implementation follows Gaspari & Cohn (1999).  Distances greater than
+    twice the localisation radius receive zero weight.
+    """
+
+    if radius <= 0.0:
+        raise ValueError("The localisation radius must be positive")
+
+    dist = np.asarray(distances, dtype=float)
+    x = dist / float(radius)
+
+    weights = np.zeros_like(x)
+
+    mask1 = x <= 1.0
+    if np.any(mask1):
+        x1 = x[mask1]
+        weights[mask1] = (((-0.25 * x1 + 0.5) * x1 + 0.625) * x1 - 5.0 / 3.0) * x1**2 + 1.0
+
+    mask2 = (x > 1.0) & (x < 2.0)
+    if np.any(mask2):
+        x2 = x[mask2]
+        weights[mask2] = ((((0.125 * x2 - 0.5) * x2 + 0.625) * x2 + 5.0 / 3.0) * x2 - 5.0) * x2 + 4.0
+        weights[mask2] -= 2.0 / (3.0 * x2)
+
+    weights[x >= 2.0] = 0.0
+    np.maximum(weights, 0.0, out=weights)
+    return weights

--- a/pyletkf/mpi.py
+++ b/pyletkf/mpi.py
@@ -1,0 +1,25 @@
+"""Helpers for optional MPI support."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from typing import Any
+
+MPI: Any | None
+_spec = importlib.util.find_spec("mpi4py")
+if _spec is None:
+    MPI = None
+else:
+    mpi4py = importlib.import_module("mpi4py")
+    MPI = mpi4py.MPI
+
+__all__ = ["MPI", "get_world_comm"]
+
+
+def get_world_comm():
+    """Return :data:`mpi4py.MPI.COMM_WORLD` when MPI is available."""
+
+    if MPI is None:
+        return None
+    return MPI.COMM_WORLD

--- a/pyletkf/run.py
+++ b/pyletkf/run.py
@@ -1,0 +1,150 @@
+"""Command line interface to run the Python LETKF pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import xarray as xr
+
+from .assimilation import run_letkf_assimilation
+from .io import load_ensemble, load_observations, save_outputs
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+
+def _load_obs_error(
+    obs: xr.DataArray,
+    *,
+    obs_error_std: float | None,
+    obs_error_var_name: str | None,
+    obs_dataset_path: Path,
+) -> float | xr.DataArray:
+    if obs_error_var_name:
+        with xr.open_dataset(obs_dataset_path) as ds:
+            if obs_error_var_name not in ds:
+                raise KeyError(
+                    f"Observation error variable {obs_error_var_name!r} not found in {obs_dataset_path!s}"
+                )
+            obs_var = ds[obs_error_var_name].load()
+        if obs_var.dims != obs.dims:
+            LOGGER.warning("Observation error field dimensions differ from observations; attempting alignment")
+        return obs_var
+
+    if obs_error_std is None:
+        raise ValueError("Either an observation error standard deviation or a variable name must be provided")
+    if obs_error_std <= 0.0:
+        raise ValueError("Observation error standard deviation must be positive")
+    return float(obs_error_std) ** 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a LETKF experiment using xarray inputs")
+    parser.add_argument("--hist-dir", required=True, help="Directory containing historical ensemble NetCDF files")
+    parser.add_argument("--fut-dir", required=True, help="Directory containing future ensemble NetCDF files")
+    parser.add_argument("--obs", required=True, help="Observation NetCDF file")
+    parser.add_argument("--var", required=True, help="Variable name present in ensemble files")
+    parser.add_argument(
+        "--obs-var",
+        default=None,
+        help="Variable name holding the observations (defaults to --var)",
+    )
+    parser.add_argument(
+        "--obs-error-std",
+        type=float,
+        default=None,
+        help="Observation error standard deviation (constant for all observations)",
+    )
+    parser.add_argument(
+        "--obs-error-var-name",
+        default=None,
+        help="Name of the variable in the observation file holding the error variance",
+    )
+    parser.add_argument("--time-dim", default="year", help="Name of the temporal dimension")
+    parser.add_argument("--member-dim", default="member", help="Name of the ensemble member dimension")
+    parser.add_argument("--inflation", type=float, default=1.0, help="Background covariance inflation parameter")
+    parser.add_argument("--output-dir", required=True, help="Directory where NetCDF outputs will be written")
+    parser.add_argument(
+        "--metadata",
+        default=None,
+        help="Optional JSON file storing run metadata to be embedded in the outputs",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+
+    args = parser.parse_args(argv)
+    _configure_logging(args.verbose)
+
+    obs_var_name = args.obs_var or args.var
+
+    hist = load_ensemble(args.hist_dir, args.var, member_dim=args.member_dim)
+    spatial_coords = {
+        dim: hist.coords[dim]
+        for dim in hist.dims
+        if dim not in (args.member_dim, args.time_dim) and dim in hist.coords
+    }
+    fut = load_ensemble(args.fut_dir, args.var, member_dim=args.member_dim, load_coords=spatial_coords)
+    obs = load_observations(args.obs, obs_var_name)
+
+    obs_error_var = _load_obs_error(
+        obs,
+        obs_error_std=args.obs_error_std,
+        obs_error_var_name=args.obs_error_var_name,
+        obs_dataset_path=Path(args.obs),
+    )
+
+    result = run_letkf_assimilation(
+        hist,
+        fut,
+        obs,
+        member_dim=args.member_dim,
+        time_dim=args.time_dim,
+        obs_error_var=obs_error_var,
+        inflation=args.inflation,
+    )
+
+    time_dim = args.time_dim
+    hist_len = hist.sizes[time_dim]
+
+    prior_mean_hist = result.prior_mean.isel({time_dim: slice(0, hist_len)})
+    prior_std_hist = result.prior_std.isel({time_dim: slice(0, hist_len)})
+    post_mean_hist = result.post_mean.isel({time_dim: slice(0, hist_len)})
+    post_std_hist = result.post_std.isel({time_dim: slice(0, hist_len)})
+
+    prior_mean_fut = result.prior_mean.isel({time_dim: slice(hist_len, None)})
+    prior_std_fut = result.prior_std.isel({time_dim: slice(hist_len, None)})
+    post_mean_fut = result.post_mean.isel({time_dim: slice(hist_len, None)})
+    post_std_fut = result.post_std.isel({time_dim: slice(hist_len, None)})
+
+    outputs: dict[str, xr.DataArray] = {
+        "hist_prior_mean.nc": prior_mean_hist.rename(f"{args.var}_prior_mean"),
+        "hist_prior_std.nc": prior_std_hist.rename(f"{args.var}_prior_std"),
+        "hist_post_mean.nc": post_mean_hist.rename(f"{args.var}_post_mean"),
+        "hist_post_std.nc": post_std_hist.rename(f"{args.var}_post_std"),
+        "fut_prior_mean.nc": prior_mean_fut.rename(f"{args.var}_prior_mean"),
+        "fut_prior_std.nc": prior_std_fut.rename(f"{args.var}_prior_std"),
+        "fut_post_mean.nc": post_mean_fut.rename(f"{args.var}_post_mean"),
+        "fut_post_std.nc": post_std_fut.rename(f"{args.var}_post_std"),
+    }
+
+    if args.metadata:
+        metadata_path = Path(args.metadata)
+        with metadata_path.open("r", encoding="utf-8") as handle:
+            metadata: dict[str, Any] = json.load(handle)
+        for data in outputs.values():
+            data.attrs.update(metadata)
+
+    save_outputs(outputs, args.output_dir)
+    LOGGER.info("Analysis inflation parameter: %.3f", result.inflation)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/run_pyletkf.sh
+++ b/run_pyletkf.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 -m pyletkf.run "$@"


### PR DESCRIPTION
## Summary
- add a Python package that reads historical and future ensemble NetCDF members, observations, and saves results
- implement an LETKF driver that updates only the ensemble mean and spread while handling irregular observations
- provide a command line entry point to concatenate historical/future data, run the analysis, and emit the requested NetCDF outputs

## Testing
- python -m compileall pyletkf

------
https://chatgpt.com/codex/tasks/task_e_68c9169947ec8322b4b8e627ad22ab03